### PR TITLE
Changed OSS to FOSS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# Awesome OSS Funding [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+# Awesome FLOSS Funding [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
-> A curated list of awesome resources for funding open source projects and authors.
+*A curated list of awesome resources for funding Free/Libre and Open Source projects and authors.*
 
 
 ## Contents
@@ -19,10 +19,10 @@
 
 ## Products
 
-- [Saasify](https://saasify.sh) - Provides monetized APIs on top of OSS projects.
+- [Saasify](https://saasify.sh) - Provides monetized APIs on top of FLOSS projects.
 - [Codefund](https://codefund.io) - Provides funding for makers via ethical ads.
-- [Tidelift](https://tidelift.com) - Provides subscriptions connecting businesses with OSS devs.
-- [FOSSA](https://fossa.com) - Open source management for enterprise teams.
+- [Tidelift](https://tidelift.com) - Provides subscriptions connecting businesses with FLOSS devs.
+- [FOSSA](https://fossa.com) - Free/Libre and Open source management for enterprise teams.
 - [Gitcoin](https://gitcoin.co) - Crowdfunding and freelance devs for your software projects.
 
 
@@ -32,30 +32,29 @@
 - [Patreon](https://www.patreon.com) - Membership and recurring donations for independent creators.
 - [Open Collective](https://opencollective.com) - Open communities with full financial transparency.
 - [Buy me a coffee](https://www.buymeacoffee.com) - Donations and relationship building for independent creators.
-- [Salt](https://salt.bountysource.com) - Crowdfunding to help devs earn a monthly salary from OSS.
-- [Libera](https://liberapay.com) - Recurring donations for OSS projects.
-- [Flattr](https://flattr.com) - Monthly subscription for donating to OSS projects.
-- [thanks](https://github.com/feross/thanks) - Give thanks to the open source maintainers you depend on.
+- [Salt](https://salt.bountysource.com) - Crowdfunding to help devs earn a monthly salary from FLOSS.
+- [Libera](https://liberapay.com) - Recurring donations for FLOSS projects.
+- [Flattr](https://flattr.com) - Monthly subscription for donating to FLOSS projects.
+- [thanks](https://github.com/feross/thanks) - Give thanks to the Free/Libre and Open Source maintainers you depend on.
 
 
 ## Bounties
 
-- [Issuehunt](https://issuehunt.io) - Issue-based crowd sourcing/funding for OSS projects.
-- [Bountysource](https://www.bountysource.com) - Bounty-based funding for OSS projects.
+- [Issuehunt](https://issuehunt.io) - Issue-based crowd sourcing/funding for FLOSS projects.
+- [Bountysource](https://www.bountysource.com) - Bounty-based funding for FLOSS projects.
 
 
 ## Licensing
 
-- [License Zero](https://licensezero.com) - For-profit licenses for OSS projects.
 - [xs:code](https://xscode.com) - Paid subscriptions for OSS projects.
 
 
 ## Articles
 
-- [Lemonade Stand](https://github.com/nayafia/lemonade-stand) - The de facto living survey of different approaches for funding OSS.
-- [Getting paid for OSS](https://opensource.guide/getting-paid) - A solid guide for traditional means of funding OSS.
+- [Lemonade Stand](https://github.com/nayafia/lemonade-stand) - The de facto living survey of different approaches for funding FLOSS.
+- [Getting paid for OSS](https://opensource.guide/getting-paid) - A solid guide for traditional means of funding FLOSS.
 - [Why funding open source is hard](https://codefund.io/blog/why-funding-open-source-is-hard) - Awesome read by [Eric Berry](https://twitter.com/coderberry).
-- [How to keep the lights on at Codefund](https://codefund.io/blog/the-open-source-conundrum-how-do-we-keep-the-lights-on) - Excellent analysis of different approaches to OSS funding by [Eric Berry](https://twitter.com/coderberry).
+- [How to keep the lights on at Codefund](https://codefund.io/blog/the-open-source-conundrum-how-do-we-keep-the-lights-on) - Excellent analysis of different approaches to FLOSS funding by [Eric Berry](https://twitter.com/coderberry).
 - [Fighting for open source sustainability](https://codefund.io/blog/fighting-for-open-source-sustainability)
 - [Funding experiment recap](https://feross.org/funding-experiment-recap) - Great breakdown and insights by [Feross](http://feross.org).
 - [Should OSS advertise?](https://www.infoworld.com/article/3435114/should-open-source-software-advertise.html)
@@ -73,7 +72,7 @@
 
 ## Organizations
 
-- [Sustain OSS](https://sustainoss.org) - Organization focused on making OSS more sustainable.
+- [Sustain OSS](https://sustainoss.org) - Organization focused on making FLOSS more sustainable.
 - [COSS Media](https://coss.media) - Resources to help Commercial OSS (COSS) founders build lasting companies.
 - [Open Core Summit](https://opencoresummit.com) - Focused on connecting the world's Commercial OSS (COSS) companies.
 


### PR DESCRIPTION
Regarding #1, Replacing "Open Source" with "Free/Libre and Open Source" and "OSS" with "FLOSS".

## Note:
 - Removed - [License Zero](https://licensezero.com) since despite their claim, the license they provide (Parity and Prosperity Public License) is neither approved by OSI not FSF.
 - No change applied to "Commercial OSS (COSS)" since it is specific term.